### PR TITLE
add verbose flag to CLI output

### DIFF
--- a/downloader-cli/src/main.rs
+++ b/downloader-cli/src/main.rs
@@ -30,7 +30,7 @@ async fn run(config: Config) -> Result<(), Box<dyn Error>> {
     let manifest = Manifest::build(&config.manifest_location).await?;
     let transaction = Transaction::new(manifest, base_path);
 
-    transaction.print();
+    transaction.print(config.verbose);
 
     if transaction.has_pending_operations() {
         if !prompt::confirm("Is this ok")? {

--- a/downloader-core/src/config.rs
+++ b/downloader-core/src/config.rs
@@ -32,6 +32,7 @@ pub struct Config {
     pub manifest_provider: Provider,
     pub figure_text: String,
     pub description: String,
+    pub verbose: bool,
 }
 
 impl Config {
@@ -43,17 +44,20 @@ impl Config {
                 .value_parser(clap::value_parser!(Provider))
                 .default_value("cloudflare")
                 .help("Available providers: cloudflare (Server #1), digitalocean (Server #2), none (Server #3 - Slowest)"))
+            .arg(arg!(-v --verbose "Show verbose output including empty categories"))
             .get_matches();
 
         let manifest_str = matches.get_one::<String>("manifest").unwrap().to_string();
         let manifest_location = Location::parse(manifest_str)?;
         let manifest_provider = matches.get_one::<Provider>("provider").unwrap().clone();
+        let verbose = matches.get_flag("verbose");
 
         Ok(Config {
             manifest_location,
             manifest_provider,
             figure_text: DEFAULT_FIGURE_TEXT.to_string(),
             description: DEFAULT_DESCRIPTION.to_string(),
+            verbose,
         })
     }
 }

--- a/downloader-core/src/transaction.rs
+++ b/downloader-core/src/transaction.rs
@@ -232,14 +232,16 @@ impl Transaction {
         }
     }
 
-    pub fn print(&self) {
+    pub fn print(&self, verbose: bool) {
         let report = self.generate_report();
         println!("\nManifest Overview:");
         println!(" Version: {}", report.version);
         println!(" UID: {}", report.uid);
         println!(" Base path: {}", report.base_path.display());
 
-        println!("\n {}", "Up-to-date files:".green());
+        if !report.up_to_date_files.is_empty() || verbose {
+            println!("\n {}", "Up-to-date files:".green());
+        }
         for file in &report.up_to_date_files {
             println!(
                 "  {} (Size: {})",
@@ -248,7 +250,9 @@ impl Transaction {
             );
         }
 
-        println!("\n {}", "Outdated files (will be updated):".yellow());
+        if !report.outdated_files.is_empty() || verbose {
+            println!("\n {}", "Outdated files (will be updated):".yellow());
+        }
         for file in &report.outdated_files {
             println!(
                 "  {} (Current Size: {}, New Size: {})",
@@ -258,7 +262,9 @@ impl Transaction {
             );
         }
 
-        println!("\n {}", "Missing files (will be downloaded):".red());
+        if !report.missing_files.is_empty() || verbose {
+            println!("\n {}", "Missing files (will be downloaded):".red());
+        }
         for file in &report.missing_files {
             println!(
                 "  {} (New Size: {})",
@@ -267,7 +273,9 @@ impl Transaction {
             );
         }
 
-        println!("\n {}", "Files to be removed:".magenta());
+        if !report.removed_files.is_empty() || verbose {
+            println!("\n {}", "Files to be removed:".magenta());
+        }
         for file in &report.removed_files {
             println!(
                 "  {} (Current Size: {})",

--- a/downloader-core/src/transaction.rs
+++ b/downloader-core/src/transaction.rs
@@ -239,50 +239,76 @@ impl Transaction {
         println!(" UID: {}", report.uid);
         println!(" Base path: {}", report.base_path.display());
 
-        if !report.up_to_date_files.is_empty() || verbose {
-            println!("\n {}", "Up-to-date files:".green());
-        }
-        for file in &report.up_to_date_files {
-            println!(
-                "  {} (Size: {})",
-                file.path.green(),
-                humansize::format_size(file.new_size as u64, BINARY)
-            );
-        }
+        // Helper closure to print a file category section
+        let print_section =
+            |files: &[FileReport],
+             header: &str,
+             color_fn: fn(&str) -> colored::ColoredString,
+             format_fn: &dyn Fn(&FileReport) -> String| {
+                if !files.is_empty() || verbose {
+                    println!("\n {}", color_fn(header));
+                    for file in files {
+                        println!("  {}", format_fn(file));
+                    }
+                }
+            };
 
-        if !report.outdated_files.is_empty() || verbose {
-            println!("\n {}", "Outdated files (will be updated):".yellow());
-        }
-        for file in &report.outdated_files {
-            println!(
-                "  {} (Current Size: {}, New Size: {})",
-                file.path.yellow(),
-                humansize::format_size(file.current_size.unwrap() as u64, BINARY),
-                humansize::format_size(file.new_size as u64, BINARY)
-            );
-        }
+        // Up-to-date files
+        print_section(
+            &report.up_to_date_files,
+            "Up-to-date files:",
+            |s| s.green(),
+            &|file| {
+                format!(
+                    "{} (Size: {})",
+                    file.path.green(),
+                    humansize::format_size(file.new_size as u64, BINARY)
+                )
+            },
+        );
 
-        if !report.missing_files.is_empty() || verbose {
-            println!("\n {}", "Missing files (will be downloaded):".red());
-        }
-        for file in &report.missing_files {
-            println!(
-                "  {} (New Size: {})",
-                file.path.red(),
-                humansize::format_size(file.new_size as u64, BINARY)
-            );
-        }
+        // Outdated files
+        print_section(
+            &report.outdated_files,
+            "Outdated files (will be updated):",
+            |s| s.yellow(),
+            &|file| {
+                format!(
+                    "{} (Current Size: {}, New Size: {})",
+                    file.path.yellow(),
+                    humansize::format_size(file.current_size.unwrap() as u64, BINARY),
+                    humansize::format_size(file.new_size as u64, BINARY)
+                )
+            },
+        );
 
-        if !report.removed_files.is_empty() || verbose {
-            println!("\n {}", "Files to be removed:".magenta());
-        }
-        for file in &report.removed_files {
-            println!(
-                "  {} (Current Size: {})",
-                file.path.magenta(),
-                humansize::format_size(file.current_size.unwrap_or(0) as u64, BINARY)
-            );
-        }
+        // Missing files
+        print_section(
+            &report.missing_files,
+            "Missing files (will be downloaded):",
+            |s| s.red(),
+            &|file| {
+                format!(
+                    "{} (New Size: {})",
+                    file.path.red(),
+                    humansize::format_size(file.new_size as u64, BINARY)
+                )
+            },
+        );
+
+        // Files to be removed
+        print_section(
+            &report.removed_files,
+            "Files to be removed:",
+            |s| s.magenta(),
+            &|file| {
+                format!(
+                    "{} (Current Size: {})",
+                    file.path.magenta(),
+                    humansize::format_size(file.current_size.unwrap_or(0) as u64, BINARY)
+                )
+            },
+        );
 
         if self.has_pending_operations() {
             println!("\nTransaction Summary:");

--- a/launcher-gui/src-tauri/src/lib.rs
+++ b/launcher-gui/src-tauri/src/lib.rs
@@ -60,7 +60,7 @@ async fn create_transaction(
     // Create a transaction
     let transaction = Transaction::new(manifest, base_path);
     #[cfg(debug_assertions)]
-    transaction.print(); // Generate a report and print to stdout
+    transaction.print(true);
 
     let report = transaction.generate_report();
     {


### PR DESCRIPTION
by default empty categories should not be displayed as part of the transaction overview