### PR TITLE
ci: reduce amount of workflows that are triggered.

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -31,13 +31,13 @@ jobs:
       - name: test docs
         run: cargo test --doc
 
-  build-cli-linux-windows:
+  build-cli-linux:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: moonrepo/setup-rust@v1
         with:
-          targets: x86_64-unknown-linux-gnu, x86_64-pc-windows-gnu
+          targets: x86_64-unknown-linux-gnu
       - name: Prepare dist directory
         run: mkdir -p dist/cli
       - name: Copy LICENSE to dist
@@ -46,65 +46,3 @@ jobs:
         run: |
           cd downloader-cli
           cargo build --locked --release --target x86_64-unknown-linux-gnu
-          mv ../target/x86_64-unknown-linux-gnu/release/downloader-cli ../dist/cli/downloader-cli-linux-x86_64
-      - name: Build Linux (Production)
-        run: |
-          cd downloader-cli
-          cargo build --features production --locked --release --target x86_64-unknown-linux-gnu --bin downloader-cli
-          mv ../target/x86_64-unknown-linux-gnu/release/downloader-cli ../dist/cli/epoch_patcher-cli-linux-x86_64
-      - name: Setup Windows - Install mingw-w64
-        run: sudo apt-get install -y mingw-w64
-      - name: Build Windows (Demo)
-        run: |
-          cd downloader-cli
-          cargo build --locked --release --target x86_64-pc-windows-gnu
-          mv ../target/x86_64-pc-windows-gnu/release/downloader-cli.exe ../dist/cli/downloader-cli-windows-x86_64.exe
-      - name: Build Windows (Production)
-        run: |
-          cd downloader-cli
-          cargo build --features production --locked --release --target x86_64-pc-windows-gnu --bin downloader-cli
-          mv ../target/x86_64-pc-windows-gnu/release/downloader-cli.exe ../dist/cli/epoch_patcher-cli-windows-x86_64.exe
-      - name: Upload CLI artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-artifacts
-          path: dist/cli/
-          retention-days: 3
-
-  build-cli-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: moonrepo/setup-rust@v1
-        with:
-          targets: x86_64-apple-darwin,aarch64-apple-darwin
-      - name: Prepare dist directory
-        run: mkdir -p dist/cli
-      - name: Copy LICENSE to dist
-        run: cp LICENSE dist/
-      - name: Build macOS (Intel, Demo)
-        run: |
-          cd downloader-cli
-          cargo build --locked --release --target x86_64-apple-darwin
-          mv ../target/x86_64-apple-darwin/release/downloader-cli ../dist/cli/downloader-cli-macos-x86_64
-      - name: Build macOS (Intel, Production)
-        run: |
-          cd downloader-cli
-          cargo build --features production --locked --release --target x86_64-apple-darwin --bin downloader-cli
-          mv ../target/x86_64-apple-darwin/release/downloader-cli ../dist/cli/epoch_patcher-cli-macos-x86_64
-      - name: Build macOS (Apple Silicon, Demo)
-        run: |
-          cd downloader-cli
-          cargo build --locked --release --target aarch64-apple-darwin
-          mv ../target/aarch64-apple-darwin/release/downloader-cli ../dist/cli/downloader-cli-macos-aarch64
-      - name: Build macOS (Apple Silicon, Production)
-        run: |
-          cd downloader-cli
-          cargo build --features production --locked --release --target aarch64-apple-darwin --bin downloader-cli
-          mv ../target/aarch64-apple-darwin/release/downloader-cli ../dist/cli/epoch_patcher-cli-macos-aarch64
-      - name: Upload CLI artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-artifacts-macos
-          path: dist/cli/
-          retention-days: 3

--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -10,20 +10,7 @@ concurrency:
 
 jobs:
   test-tauri:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
-          - platform: "macos-latest" # for Intel based macs.
-            args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
-            args: ""
-          - platform: "windows-latest"
-            args: ""
-
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: setup node
@@ -32,13 +19,9 @@ jobs:
           node-version: lts/*
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -52,5 +35,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: launcher-gui
-          args: ${{ matrix.args }}
-          releaseName: "Launcher GUI v${{ github.event.inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,101 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      run_id:
-        description: 'Run ID of the build workflow (build-cli.yml) to use for the artifacts'
-        required: true
-        default: '13042045029'
       version:
         description: 'desired version'
         required: true
-        default: 'v0.1.7'
+        default: 'v0.1.9'
 
 jobs:
+  build-cli-all-platforms:
+    strategy:
+      matrix:
+        include:
+          - platform: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            artifact-name: cli-artifacts
+            setup-windows: true
+          - platform: macos-latest
+            target: x86_64-apple-darwin,aarch64-apple-darwin
+            artifact-name: cli-artifacts-macos
+            setup-windows: false
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
+        with:
+          targets: ${{ matrix.target }}${{ matrix.setup-windows && ',x86_64-pc-windows-gnu' || '' }}
+      - name: Prepare dist directory
+        run: mkdir -p dist/cli
+      - name: Copy LICENSE to dist
+        run: cp LICENSE dist/
+
+      # Linux builds (on Ubuntu runner)
+      - name: Build Linux (Demo)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          cd downloader-cli
+          cargo build --locked --release --target x86_64-unknown-linux-gnu
+          mv ../target/x86_64-unknown-linux-gnu/release/downloader-cli ../dist/cli/downloader-cli-linux-x86_64
+      - name: Build Linux (Production)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          cd downloader-cli
+          cargo build --features production --locked --release --target x86_64-unknown-linux-gnu --bin downloader-cli
+          mv ../target/x86_64-unknown-linux-gnu/release/downloader-cli ../dist/cli/epoch_patcher-cli-linux-x86_64
+
+      # Windows builds (on Ubuntu runner with cross-compilation)
+      - name: Setup Windows - Install mingw-w64
+        if: matrix.platform == 'ubuntu-24.04'
+        run: sudo apt-get install -y mingw-w64
+      - name: Build Windows (Demo)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          cd downloader-cli
+          cargo build --locked --release --target x86_64-pc-windows-gnu
+          mv ../target/x86_64-pc-windows-gnu/release/downloader-cli.exe ../dist/cli/downloader-cli-windows-x86_64.exe
+
+      - name: Build Windows (Production)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          cd downloader-cli
+          cargo build --features production --locked --release --target x86_64-pc-windows-gnu --bin downloader-cli
+          mv ../target/x86_64-pc-windows-gnu/release/downloader-cli.exe ../dist/cli/epoch_patcher-cli-windows-x86_64.exe
+
+      # macOS builds (on macOS runner)
+      - name: Build macOS (Intel, Demo)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          cd downloader-cli
+          cargo build --locked --release --target x86_64-apple-darwin
+          mv ../target/x86_64-apple-darwin/release/downloader-cli ../dist/cli/downloader-cli-macos-x86_64
+      - name: Build macOS (Intel, Production)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          cd downloader-cli
+          cargo build --features production --locked --release --target x86_64-apple-darwin --bin downloader-cli
+          mv ../target/x86_64-apple-darwin/release/downloader-cli ../dist/cli/epoch_patcher-cli-macos-x86_64
+      - name: Build macOS (Apple Silicon, Demo)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          cd downloader-cli
+          cargo build --locked --release --target aarch64-apple-darwin
+          mv ../target/aarch64-apple-darwin/release/downloader-cli ../dist/cli/downloader-cli-macos-aarch64
+      - name: Build macOS (Apple Silicon, Production)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          cd downloader-cli
+          cargo build --features production --locked --release --target aarch64-apple-darwin --bin downloader-cli
+          mv ../target/aarch64-apple-darwin/release/downloader-cli ../dist/cli/epoch_patcher-cli-macos-aarch64
+      - name: Upload CLI artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: dist/cli/
+          retention-days: 3
+
   publish-production:
+    needs: build-cli-all-platforms
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -23,16 +107,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cli-artifacts
-          run-id: ${{ github.event.inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: dist/cli/
 
       - name: Download macOS Artifacts
         uses: actions/download-artifact@v4
         with:
           name: cli-artifacts-macos
-          run-id: ${{ github.event.inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: dist/cli/
 
       - name: Create Production Release
@@ -54,6 +134,7 @@ jobs:
             README.md
 
   publish-demo:
+    needs: build-cli-all-platforms
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -63,16 +144,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cli-artifacts
-          run-id: ${{ github.event.inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: dist/cli/
 
       - name: Download macOS Artifacts
         uses: actions/download-artifact@v4
         with:
           name: cli-artifacts-macos
-          run-id: ${{ github.event.inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: dist/cli/
 
       - name: Create Demo Release
@@ -94,6 +171,7 @@ jobs:
             README.md
 
   publish-demo-tauri:
+    needs: build-cli-all-platforms # only build the GUI once all CLI artifacts are ready
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
Only build Windows and macOS on the release workflow