### PR TITLE
feat: windows display uac permission error

### DIFF
--- a/downloader-cli/src/main.rs
+++ b/downloader-cli/src/main.rs
@@ -23,6 +23,19 @@ fn main() {
     let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
     if let Err(e) = rt.block_on(run(config)) {
         println!("Application error: {e}");
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+                if io_err.kind() == std::io::ErrorKind::PermissionDenied {
+                    println!("Permission denied. Please run this program as administrator.");
+                    println!("Right-click the executable and choose 'Run as administrator'.");
+                }
+            }
+            println!("\nPress Enter to exit...");
+            let _ = std::io::stdout().flush();
+            let mut input = String::new();
+            let _ = std::io::stdin().read_line(&mut input);
+        }
         process::exit(1);
     }
 }


### PR DESCRIPTION
Windows: No longer closes the console when attempting to write to UAC-protected directories like Program Files, instead we display a message to ask to with admin permissions